### PR TITLE
feature: abstracted database client

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -1,6 +1,12 @@
-// Currently this is unused, and will stay so until the model and api are finished and I can transition from the PasteManager's mock storage to an actual database
+use crate::model::PasteError;
 use rusqlite::Connection;
+use std::sync::{Arc, Mutex};
+
+pub type Result<T> = std::result::Result<T, PasteError>;
+
+/// Database connector
 pub struct Database {}
+
 impl Database {
     pub fn init() -> Connection {
         let conn = Connection::open("main.db").unwrap();
@@ -12,11 +18,104 @@ impl Database {
                  content        text,
                  date_published text,
                  date_edited    text
-             )", ());
+             )",
+            (),
+        );
         match table_result {
-            Ok(_)  => println!("Successfully connected to table."),
-            Err(e) => panic!("Database creation failed with error message: {e}")
+            Ok(_) => println!("Successfully connected to table."),
+            Err(e) => panic!("Database creation failed with error message: {e}"),
         };
         conn
+    }
+}
+
+/// Client manager for the database
+///
+/// Currently this is unused, and will stay so until the model and api are finished and I can transition from the PasteManager's mock storage to an actual database
+#[derive(Clone)]
+pub struct ClientManager<T> {
+    /// Temporary store, it's labeled "pool" but is not currently a pool
+    pool: ConnectionPool<T>,
+}
+
+type ConnectionPool<T> = Arc<Mutex<Vec<T>>>;
+
+impl<T: std::ops::Index<String, Output = String> + Clone> ClientManager<T> {
+    /// Create new [`Client`]
+    pub fn new(pool: ConnectionPool<T>) -> Self {
+        Self { pool }
+    }
+
+    // This is not needed when replaced with SQL methods
+    pub fn len(&self) -> usize {
+        // obtain client from pool
+        let client = self.pool.lock().unwrap();
+
+        // return
+        client.len()
+    }
+
+    // functions below should be altered when proper database support is added
+    // we only really need to select one thing at a time since the api is pretty basic,
+    // so these functions only do what is needed ... optionally this could all be replaced
+    // with a `run_query` function (or something)
+
+    /// Select by a given `field`
+    ///
+    /// ## Arguments:
+    /// * `field` - the field we are selecting by
+    /// * `equals` - what the field value needs to equal
+    pub fn select_single(&self, field: String, equals: &str) -> Result<T> {
+        // obtain client from pool
+        let client = self.pool.lock().unwrap();
+
+        // select
+        // (replace with sql "SELECT FROM ... WHERE ... LIMIT 1", this just implements a basic version)
+        let entry = client.iter().clone().find(|r| r[field.clone()] == equals);
+
+        match entry {
+            // we need T to impl Clone so we can do this
+            Some(r) => Ok((*r).to_owned()),
+            None => Err(PasteError::NotFound),
+        }
+    }
+
+    /// Insert `T`
+    ///
+    /// ## Arguments:
+    /// * `value`: `T`
+    pub fn insert_row(&self, value: T) -> Result<()> {
+        // obtain client from pool
+        let mut client = self.pool.lock().unwrap();
+
+        // push and return
+        client.push(value);
+        Ok(())
+    }
+
+    /// Remove row by `field`
+    ///
+    /// ## Arguments:
+    /// * `field` - the field we are selecting by
+    /// * `equals` - what the field value needs to equal
+    pub fn remove_single(&self, field: String, equals: &str) -> Result<()> {
+        // obtain client from pool
+        let mut client = self.pool.lock().unwrap();
+
+        // remove
+        // (replace with sql "REMOVE FROM ... WHERE ... LIMIT 1", this just implements a basic version)
+
+        // this is very bad and only for testing, it'll go through everything to find what we want
+        for (i, row) in client.clone().iter().enumerate() {
+            if row[field.clone()] != equals {
+                continue;
+            }
+
+            client.remove(i);
+            break;
+        }
+
+        // return
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod database;
+pub mod model;
 pub mod routing;
 pub mod utility;
-pub mod model;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,5 @@
-use pasties::{
-    routing::api, 
-    routing::pages,
-    model::PasteManager
-};
-use axum::{
-    Router, 
-    routing::get,
-};
+use axum::{routing::get, Router};
+use pasties::{model::PasteManager, routing::api, routing::pages};
 #[tokio::main]
 async fn main() {
     const PORT: u16 = 7878;
@@ -16,7 +9,9 @@ async fn main() {
     let app = Router::new()
         .route("/", get(pages::root))
         .nest("/api", api::routes(manager.clone()));
-    let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{PORT}")).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{PORT}"))
+        .await
+        .unwrap();
 
     println!("Starting server at http://localhost:{PORT}!");
     axum::serve(listener, app).await.unwrap();

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,46 +1,86 @@
 //! `model` manages the CRUD loop for pastes
-use std::sync::{Arc, Mutex};
-use axum::{http::StatusCode, response::{IntoResponse, Response}};
-use serde::{Serialize, Deserialize};
-use crate::utility::unix_timestamp;
+use crate::{database::ClientManager, utility::unix_timestamp};
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Paste {
-    id:             u32,
-    url:            String,
-    content:        String,
-    password:       String,
+    id: u32,
+    url: String,
+    content: String,
+    password: String,
     date_published: u64,
-    date_edited:    u64
+    date_edited: u64,
 }
+
+// This is only needed when using Arc<Mutex<Vec<Paste>>>
+// It only exists so we can do `paste[field]``
+impl std::ops::Index<String> for Paste {
+    type Output = String;
+
+    fn index(&self, index: String) -> &Self::Output {
+        match index.as_ref() {
+            "url" => &self.url,
+            _ => todo!(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PasteCreate {
-    url:            String,
-    content:        String,
-    password:       String
+    url: String,
+    content: String,
+    password: String,
 }
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PasteDelete {
+    pub(super) password: String,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PasteReturn {
-    url:            String,
-    content:        String,
+    url: String,
+    content: String,
     date_published: u64,
-    date_edited:    u64
+    date_edited: u64,
 }
+
 pub enum PasteError {
+    PasswordIncorrect,
     AlreadyExists,
     NotFound,
-    Other
+    Other,
 }
+
 impl IntoResponse for PasteError {
     fn into_response(self) -> Response {
         use crate::model::PasteError::*;
         match self {
-            AlreadyExists =>
-                (StatusCode::INTERNAL_SERVER_ERROR, "A paste with this URL already exists.").into_response(),
-            NotFound =>
-                (StatusCode::NOT_FOUND, "No paste with this URL has been found.").into_response(),
-            _ => 
-                (StatusCode::INTERNAL_SERVER_ERROR, "An unspecified error occured with the paste manager").into_response()
+            PasswordIncorrect => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "The given password is invalid.",
+            )
+                .into_response(),
+            AlreadyExists => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "A paste with this URL already exists.",
+            )
+                .into_response(),
+            NotFound => (
+                StatusCode::NOT_FOUND,
+                "No paste with this URL has been found.",
+            )
+                .into_response(),
+            _ => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "An unspecified error occured with the paste manager",
+            )
+                .into_response(),
         }
     }
 }
@@ -48,63 +88,83 @@ impl IntoResponse for PasteError {
 #[derive(Clone)]
 pub struct PasteManager {
     // This will eventually be a lot more elaborate as a database is implemented, currently this mock storage is here so I can test the API
-    pastes: Arc<Mutex<Vec<Paste>>>
+    manager: ClientManager<Paste>,
 }
+
 /// CRUD manager for pastes
-/// 
+///
 /// TODO: use an actual database instead of in-memory `Arc<Mutex<Vec<Paste>>>`
 impl PasteManager {
     /// Returns a new instance of `PasteManager`
     pub async fn init() -> Self {
         Self {
-            pastes: Arc::default()
+            manager: ClientManager::new(Arc::default()),
         }
     }
+
     /// Creates a new `Paste` from the input `PasteCreate`
-    /// 
+    ///
     /// **Returns:** `Result<(), PasteError>`
     pub async fn create_paste(&self, paste: PasteCreate) -> Result<(), PasteError> {
-        let mut store = self.pastes.lock().unwrap();
-        if let Some(_) = store.iter().find(|p| p.url == paste.url) {
-            return Err(PasteError::AlreadyExists)
-        }
-        let id = store.len() as u32;
-        store.push(Paste{
-            id,             // Eventually this should come from the DB's unique ID
-            url:            paste.url,
-            content:        paste.content,
-            password:       paste.password,
+        // make sure paste doesn't already exist
+        if let Ok(_) = self.manager.select_single(String::from("url"), &paste.url) {
+            return Err(PasteError::AlreadyExists);
+        };
+
+        // push
+        let id = self.manager.len() as u32;
+
+        match self.manager.insert_row(Paste {
+            id, // Eventually this should come from the DB's unique ID
+            url: paste.url,
+            content: paste.content,
+            password: paste.password,
             date_published: unix_timestamp(),
-            date_edited:    unix_timestamp()
-        });
-        Ok(())
+            date_edited: unix_timestamp(),
+        }) {
+            Ok(_) => Ok(()),
+            Err(_) => Err(PasteError::Other),
+        }
     }
+
     /// Retrieves a `Paste` from `PasteManager` by its `url`
-    /// 
+    ///
     /// **Returns:** `Option<PasteReturn>`, where `None` signifies that the paste has not been found
     pub async fn get_paste_by_url(&self, paste_url: String) -> Result<PasteReturn, PasteError> {
-        let store = self.pastes.lock().unwrap();
-        // let mut filtered: Vec<PasteReturn> = store
-        //     .clone().iter()
-        //     .filter(|paste| paste.url == paste_url)
-        //     .map(|paste| PasteReturn { 
-        //         url: paste.url.to_owned(),
-        //         content: paste.content.to_owned(),
-        //         date_published: paste.date_published,
-        //         date_edited: paste.date_edited
-        //     })
-        //     .collect();
-        let searched_paste = store.iter().find(|paste| paste.url == paste_url);
+        let searched_paste = self.manager.select_single(String::from("url"), &paste_url);
+
         match searched_paste {
-            Some(p) => {
-                Ok(PasteReturn {
-                    url: p.url.to_owned(),
-                    content: p.content.to_owned(),
-                    date_published: p.date_published,
-                    date_edited: p.date_edited
-                })
-            }
-            None => Err(PasteError::NotFound)
+            Ok(p) => Ok(PasteReturn {
+                url: p.url.to_owned(),
+                content: p.content.to_owned(),
+                date_published: p.date_published,
+                date_edited: p.date_edited,
+            }),
+            Err(_) => Err(PasteError::NotFound),
         }
+    }
+
+    /// Removes a `Paste` from `PasteManager` by its `url`
+    ///
+    /// **Returns:** `Option<PasteReturn>`, where `None` signifies that the paste has not been found
+    pub async fn delete_paste_by_url(
+        &self,
+        paste_url: String,
+        password: String,
+    ) -> Result<(), PasteError> {
+        // make sure paste exists
+        let existing = match self.manager.select_single(String::from("url"), &paste_url) {
+            Ok(p) => p,
+            Err(_) => return Err(PasteError::NotFound),
+        };
+
+        // check password
+        // in the future, hashes should be compared here
+        if password != existing.password {
+            return Err(PasteError::PasswordIncorrect);
+        }
+
+        // return
+        self.manager.remove_single(String::from("url"), &paste_url)
     }
 }

--- a/src/routing/api.rs
+++ b/src/routing/api.rs
@@ -1,7 +1,9 @@
 //! `routing::api` creates an interface for the `PasteManager` CRUD struct defined in `model`
-use crate::model::{PasteCreate, PasteError, PasteManager, PasteReturn};
+use crate::model::{PasteCreate, PasteDelete, PasteError, PasteManager, PasteReturn};
 use axum::{
-    extract::{Path, State}, routing::{get, post}, Json, Router,
+    extract::{Path, State},
+    routing::{get, post},
+    Json, Router,
 };
 use axum_macros::debug_handler;
 
@@ -9,22 +11,35 @@ pub fn routes(manager: PasteManager) -> Router {
     Router::new()
         .route("/new", post(create_paste))
         .route("/:url", get(get_paste_by_url))
+        .route("/:url/delete", post(delete_paste_by_url))
         .with_state(manager)
 }
+
 async fn create_paste(
-    State(manager): State<PasteManager>, 
-    Json(paste_to_create): Json<PasteCreate>
+    State(manager): State<PasteManager>,
+    Json(paste_to_create): Json<PasteCreate>,
 ) -> Result<(), PasteError> {
     manager.create_paste(paste_to_create).await
 }
+
+async fn delete_paste_by_url(
+    State(manager): State<PasteManager>,
+    Path(url): Path<String>,
+    Json(paste_to_delete): Json<PasteDelete>,
+) -> Result<(), PasteError> {
+    manager
+        .delete_paste_by_url(url, paste_to_delete.password)
+        .await
+}
+
 #[debug_handler]
 async fn get_paste_by_url(
     State(manager): State<PasteManager>,
-    Path(url): Path<String>
+    Path(url): Path<String>,
 ) -> Result<Json<PasteReturn>, PasteError> {
     let return_paste = manager.get_paste_by_url(url).await;
     match return_paste {
-        Ok(p)  => Ok(Json(p)),
-        Err(e) => Err(e)
+        Ok(p) => Ok(Json(p)),
+        Err(e) => Err(e),
     }
 }


### PR DESCRIPTION
* adds an abstracted database client for testing that can be very easily replaced for SQL support
    * you previously would've had to replace stuff in every database method to support SQL, now everything can be replaced in one place
* adds the ability to delete existing pastes (with password check) - `POST /api/:url/delete`

There will be some formatting differences because no rustfmt configuration was provided, so my config was used.